### PR TITLE
[PAPI-103] API Versioning

### DIFF
--- a/src/app/lookups/environments.ts
+++ b/src/app/lookups/environments.ts
@@ -11,7 +11,7 @@ export interface IEnvironment {
 
 export const environments: IEnvironment[] = [
   {
-    apiUrl: 'https://v1-dev-api.opdex.com',
+    apiUrl: 'https://v1-dev-api.opdex.com/v1',
     marketAddress: 'PXToW7DpAhVAYn9Ye3TLs91jV22NqLmHWx',
     routerAddress: 'PNzmDwtPNt5EYukJZzjShsHHrjpe2y594x',
     miningGovernanceAddress: 'PHrY3DUj6DgjKZq2aWdwGiKs5FAWoy2QS2',
@@ -19,7 +19,7 @@ export const environments: IEnvironment[] = [
     network: Network.Devnet
   },
   {
-    apiUrl: 'https://v1-test-api.opdex.com',
+    apiUrl: 'https://v1-test-api.opdex.com/v1',
     marketAddress: 't7RorA7xQCMVYKPM1ibPE1NSswaLbpqLQb',
     routerAddress: 'tAFxpxRdcV9foADqD6gK3c8sY5MeANzFp5',
     miningGovernanceAddress: 'tKFkNiL5KJ3Q4br929i6hHbB4X4mt1MigF',
@@ -27,7 +27,7 @@ export const environments: IEnvironment[] = [
     network: Network.Testnet
   },
   {
-    apiUrl: 'https://v1-api.opdex.com',
+    apiUrl: 'https://v1-api.opdex.com/v1',
     marketAddress: '',
     routerAddress: '',
     miningGovernanceAddress: '',

--- a/src/environments/environment.testnet.ts
+++ b/src/environments/environment.testnet.ts
@@ -1,7 +1,7 @@
 import { Network } from 'src/app/enums/networks';
 
-// const api = 'http://localhost:44391';
-const api = 'https://v1-test-api.opdex.com';
+// const api = 'http://localhost:44391/v1';
+const api = 'https://v1-test-api.opdex.com/v1';
 
 export const environment = {
   production: false,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,7 +1,7 @@
 import { Network } from 'src/app/enums/networks';
 
-// const api = 'http://localhost:44391';
-const api = 'https://v1-dev-api.opdex.com';
+// const api = 'http://localhost:44391/v1';
+const api = 'https://v1-dev-api.opdex.com/v1';
 
 export const environment = {
   production: false,


### PR DESCRIPTION
Adds `v1` to API url path for major API versions
Based on https://github.com/Opdex/opdex-v1-api/pull/177