### PR TITLE
[PAPI-333] Transaction Fee Property Naming

### DIFF
--- a/src/app/models/platform-api/requests/markets/create-standard-market-quote-request.ts
+++ b/src/app/models/platform-api/requests/markets/create-standard-market-quote-request.ts
@@ -1,6 +1,6 @@
 export interface ICreateStandardMarketQuoteRequest {
   owner: string;
-  transactionFee: number;
+  transactionFeePercent: number;
   authPoolCreators: boolean;
   authLiquidityProviders: boolean;
   authTraders: boolean;
@@ -9,7 +9,7 @@ export interface ICreateStandardMarketQuoteRequest {
 
 export class CreateStandardMarketQuoteRequest {
   private _owner: string;
-  private _transactionFee: number;
+  private _transactionFeePercent: number;
   private _authPoolCreators: boolean;
   private _authLiquidityProviders: boolean;
   private _authTraders: boolean;
@@ -18,7 +18,7 @@ export class CreateStandardMarketQuoteRequest {
   public get payload(): ICreateStandardMarketQuoteRequest {
     return {
       owner: this._owner,
-      transactionFee: this._transactionFee,
+      transactionFeePercent: this._transactionFeePercent,
       authPoolCreators: this._authPoolCreators,
       authLiquidityProviders: this._authLiquidityProviders,
       authTraders: this._authTraders,
@@ -26,10 +26,10 @@ export class CreateStandardMarketQuoteRequest {
     }
   }
 
-  constructor(owner: string, transactionFee: number, authPoolCreators: boolean,
+  constructor(owner: string, transactionFeePercent: number, authPoolCreators: boolean,
               authLiquidityProviders: boolean, authTraders: boolean, enableMarketFee: boolean) {
     this._owner = owner;
-    this._transactionFee = transactionFee;
+    this._transactionFeePercent = transactionFeePercent;
     this._authPoolCreators = authPoolCreators;
     this._authLiquidityProviders= authLiquidityProviders;
     this._authTraders = authTraders;

--- a/src/app/models/platform-api/responses/transactions/transaction-events/deployers/create-market-event.interface.ts
+++ b/src/app/models/platform-api/responses/transactions/transaction-events/deployers/create-market-event.interface.ts
@@ -7,7 +7,7 @@ export interface ICreateMarketEvent extends ITransactionEvent {
   authPoolCreators: boolean;
   authProviders: boolean;
   authTraders: boolean;
-  transactionFee: number;
+  transactionFeePercent: number;
   stakingToken: string;
   enableMarketFee: boolean;
 }


### PR DESCRIPTION
Changed `transactionFee` to `transactionFeePercent`

related to: https://github.com/Opdex/opdex-v1-api/pull/180/files