### PR TITLE
[PAPI-375] Auth Reconnection

### DIFF
--- a/src/app/views/auth/auth.component.ts
+++ b/src/app/views/auth/auth.component.ts
@@ -25,6 +25,7 @@ export class AuthComponent implements OnInit, OnDestroy {
   expirationLength: number;
   timeRemaining: string;
   percentageTimeRemaining: number;
+  connectionId: string;
 
   constructor(
     private _context: UserContextService,
@@ -63,6 +64,8 @@ export class AuthComponent implements OnInit, OnDestroy {
 
     await this.hubConnection.start();
 
+    this.hubConnection.onreconnected(async _ => await this.hubConnection.invoke("Reconnect"));
+
     await this.getStratisId();
 
     this.hubConnection.on('OnAuthenticated', async (token: string) => {
@@ -72,6 +75,7 @@ export class AuthComponent implements OnInit, OnDestroy {
   }
 
   private async getStratisId() {
+    this.connectionId = this.hubConnection.connectionId;
     this.stratisId = await this.hubConnection.invoke('GetStratisId');
 
     if (!!this.stratisId === false || !this.stratisId.startsWith('sid:')) return;

--- a/src/app/views/auth/auth.component.ts
+++ b/src/app/views/auth/auth.component.ts
@@ -55,7 +55,7 @@ export class AuthComponent implements OnInit, OnDestroy {
 
   private async connectToSignalR(): Promise<void> {
     this.hubConnection = new HubConnectionBuilder()
-      .withUrl(`${this._env.apiUrl}/socket`,  { accessTokenFactory: () => this._jwt.getToken() })
+      .withUrl(`${this._env.apiUrl}/socket`, { accessTokenFactory: () => this._jwt.getToken() })
       .configureLogging(LogLevel.Error)
       .withAutomaticReconnect()
       .build();
@@ -64,7 +64,8 @@ export class AuthComponent implements OnInit, OnDestroy {
 
     await this.hubConnection.start();
 
-    this.hubConnection.onreconnected(async _ => await this.hubConnection.invoke("Reconnect"));
+    this.hubConnection.onreconnected(async _ =>
+      await this.hubConnection.invoke("Reconnect", this.connectionId, this.stratisId));
 
     await this.getStratisId();
 


### PR DESCRIPTION
Pull request to attempt to retrieve auth token after socket reconnect.
Will allow users to sign on the same device as their mobile wallets when switching back to Opdex. 

Related to https://github.com/Opdex/opdex-v1-api/pull/215