### PR TITLE
Refresh Token Flows

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
+    "secure-start": "ng serve -o --ssl --ssl-key ../../localhost-key.pem --ssl-cert ../../localhost.pem",
     "build": "ng build",
     "build-prod": "ng build -c prod",
     "test": "ng test",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -87,7 +87,9 @@ export class AppComponent implements OnInit, AfterContentChecked, OnDestroy {
   }
 
   async ngOnInit(): Promise<void> {
-    await this._authService.refresh();
+    this._authService.refresh()
+      .pipe(take(1))
+      .subscribe();
 
     this.subscription.add(
       this._context.userContext$

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -185,8 +185,6 @@ export class AppComponent implements OnInit, AfterContentChecked, OnDestroy {
 
     if (userIsLoggedIn && isExpired) {
       await lastValueFrom(this._authService.refresh());
-      // Stops then onclose auto reconnects w/ new jwt
-      await this.stopHubConnection();
     }
   }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -85,10 +85,11 @@ export class AppComponent implements OnInit, AfterContentChecked, OnDestroy {
   }
 
   async ngOnInit(): Promise<void> {
-    const storedToken = this._context.getToken();
-    this._context.setToken(storedToken);
+    // Get stored token and set immediately
+    this._context.setToken(this._context.token);
+
     this.subscription.add(
-      this._context.getUserContext$()
+      this._context.userContext$
         .subscribe(async context => {
           this.context = context;
           if (!context?.wallet) this.stopHubConnection();
@@ -176,7 +177,7 @@ export class AppComponent implements OnInit, AfterContentChecked, OnDestroy {
   }
 
   private validateJwt(): void {
-    const userIsLoggedIn = !!this._context.getUserContext()?.wallet;
+    const userIsLoggedIn = !!this._context.userContext?.wallet;
     const tokenIsExpired = this._jwt.isTokenExpired();
 
     if (userIsLoggedIn && tokenIsExpired) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -180,6 +180,7 @@ export class AppComponent implements OnInit, AfterContentChecked, OnDestroy {
     const tokenIsExpired = this._jwt.isTokenExpired();
 
     if (userIsLoggedIn && tokenIsExpired) {
+      // Todo: Use refresh token
       this._context.setToken('');
     }
   }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -48,7 +48,6 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { ClipboardModule } from '@angular/cdk/clipboard';
 import { MiningGovernanceComponent } from './views/mining-governance/mining-governance.component';
 import { JwtModule, JWT_OPTIONS } from '@auth0/angular-jwt';
-import { jwtOptionsFactory } from '@sharedServices/utility/jwt.service';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatSelectModule } from '@angular/material/select';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -63,6 +62,7 @@ import { VaultComponent } from './views/vault/vault.component';
 import { VaultProposalComponent } from './views/vault-proposal/vault-proposal.component';
 import { checkForUpdates } from '@sharedServices/check-for-updates';
 import { LoginComponent } from './views/login/login.component';
+import { jwtOptionsFactory } from '@sharedServices/jwt-options-factory';
 
 @NgModule({
   declarations: [

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,3 +1,4 @@
+import { AuthInterceptor } from './services/api/auth.interceptor';
 import { TxFeedModule } from './components/tx-feed-module/tx-feed.module';
 import { ControlsModule } from '@sharedComponents/controls-module/controls.module';
 import { MatInputModule } from '@angular/material/input';
@@ -6,7 +7,7 @@ import { JwtService } from './services/utility/jwt.service';
 import { BrowserModule } from '@angular/platform-browser';
 import { APP_INITIALIZER, ErrorHandler, NgModule } from '@angular/core';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -141,14 +142,10 @@ import { LoginComponent } from './views/login/login.component';
     },
     {
       provide: MAT_BOTTOM_SHEET_DEFAULT_OPTIONS,
-      useValue: {
-        hasBackdrop: true
-      }
+      useValue: { hasBackdrop: true }
     },
-    {
-      provide: ErrorHandler,
-      useClass: ErrorMiddlewareService,
-    }
+    { provide: ErrorHandler, useClass: ErrorMiddlewareService },
+    { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true }
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/components/cards-module/token-summary-card/token-summary-card.component.ts
+++ b/src/app/components/cards-module/token-summary-card/token-summary-card.component.ts
@@ -37,7 +37,7 @@ export class TokenSummaryCardComponent implements OnDestroy {
         .subscribe(block => this.latestBlock = block.height));
 
     this.subscription.add(
-      this._userContextService.userContext$
+      this._userContextService.context$
         .subscribe(context => this.context = context));
   }
 

--- a/src/app/components/cards-module/token-summary-card/token-summary-card.component.ts
+++ b/src/app/components/cards-module/token-summary-card/token-summary-card.component.ts
@@ -37,7 +37,7 @@ export class TokenSummaryCardComponent implements OnDestroy {
         .subscribe(block => this.latestBlock = block.height));
 
     this.subscription.add(
-      this._userContextService.getUserContext$()
+      this._userContextService.userContext$
         .subscribe(context => this.context = context));
   }
 

--- a/src/app/components/cards-module/vault-certificate-card/vault-certificate-card.component.ts
+++ b/src/app/components/cards-module/vault-certificate-card/vault-certificate-card.component.ts
@@ -55,7 +55,7 @@ export class VaultCertificateCardComponent implements OnDestroy {
         .subscribe(block => this.latestBlock = block.height));
 
     this.subscription.add(
-      this._userContextService.getUserContext$()
+      this._userContextService.userContext$
         .subscribe(context => this.context = context));
   }
 

--- a/src/app/components/cards-module/vault-certificate-card/vault-certificate-card.component.ts
+++ b/src/app/components/cards-module/vault-certificate-card/vault-certificate-card.component.ts
@@ -55,7 +55,7 @@ export class VaultCertificateCardComponent implements OnDestroy {
         .subscribe(block => this.latestBlock = block.height));
 
     this.subscription.add(
-      this._userContextService.userContext$
+      this._userContextService.context$
         .subscribe(context => this.context = context));
   }
 

--- a/src/app/components/cards-module/vault-proposal-card/vault-proposal-card.component.ts
+++ b/src/app/components/cards-module/vault-proposal-card/vault-proposal-card.component.ts
@@ -40,7 +40,7 @@ export class VaultProposalCardComponent implements OnDestroy {
     private _indexService: IndexService,
     private _dialog: MatDialog
   ) {
-    this.subscription.add(this._context.getUserContext$().subscribe(context => this.context = context));
+    this.subscription.add(this._context.userContext$.subscribe(context => this.context = context));
     this.subscription.add(this._indexService.status$.subscribe(status => this.indexStatus = status));
   }
 

--- a/src/app/components/cards-module/vault-proposal-card/vault-proposal-card.component.ts
+++ b/src/app/components/cards-module/vault-proposal-card/vault-proposal-card.component.ts
@@ -35,12 +35,12 @@ export class VaultProposalCardComponent implements OnDestroy {
   constructor(
     private _platformApiService: PlatformApiService,
     private _bottomSheet: MatBottomSheet,
-    private _context: UserContextService,
+    private _userContextService: UserContextService,
     private _sidenav: SidenavService,
     private _indexService: IndexService,
     private _dialog: MatDialog
   ) {
-    this.subscription.add(this._context.userContext$.subscribe(context => this.context = context));
+    this.subscription.add(this._userContextService.context$.subscribe(context => this.context = context));
     this.subscription.add(this._indexService.status$.subscribe(status => this.indexStatus = status));
   }
 

--- a/src/app/components/navigation-module/mobile-nav/mobile-nav.component.ts
+++ b/src/app/components/navigation-module/mobile-nav/mobile-nav.component.ts
@@ -23,7 +23,7 @@ export class MobileNavComponent implements OnDestroy {
     private _authService: AuthService
   ) {
     this.subscription.add(
-      this._context.getUserContext$()
+      this._context.userContext$
         .subscribe(context => this.context = context));
   }
 

--- a/src/app/components/navigation-module/mobile-nav/mobile-nav.component.ts
+++ b/src/app/components/navigation-module/mobile-nav/mobile-nav.component.ts
@@ -19,11 +19,11 @@ export class MobileNavComponent implements OnDestroy {
   subscription = new Subscription();
 
   constructor(
-    private _context: UserContextService,
+    private _userContextService: UserContextService,
     private _authService: AuthService
   ) {
     this.subscription.add(
-      this._context.userContext$
+      this._userContextService.context$
         .subscribe(context => this.context = context));
   }
 

--- a/src/app/components/navigation-module/mobile-nav/mobile-nav.component.ts
+++ b/src/app/components/navigation-module/mobile-nav/mobile-nav.component.ts
@@ -28,7 +28,7 @@ export class MobileNavComponent implements OnDestroy {
   }
 
   login(): void {
-    this._authService.login();
+    this._authService.prepareLogin();
   }
 
   toggleMenu() {

--- a/src/app/components/navigation-module/side-nav/side-nav.component.ts
+++ b/src/app/components/navigation-module/side-nav/side-nav.component.ts
@@ -51,7 +51,7 @@ export class SideNavComponent implements OnDestroy {
   }
 
   login(): void {
-    this._authService.login();
+    this._authService.prepareLogin();
   }
 
   togglePin(): void {
@@ -68,7 +68,7 @@ export class SideNavComponent implements OnDestroy {
   }
 
   logout(): void {
-    this._context.logout();
+    this._context.remove();
     this._router.navigateByUrl('/');
     this.emitRouteChange('/');
   }

--- a/src/app/components/navigation-module/side-nav/side-nav.component.ts
+++ b/src/app/components/navigation-module/side-nav/side-nav.component.ts
@@ -34,14 +34,14 @@ export class SideNavComponent implements OnDestroy {
 
   constructor(
     public dialog: MatDialog,
-    private _context: UserContextService,
+    private _userContextService: UserContextService,
     private _indexService: IndexService,
     private _transactionsService: TransactionsService,
     private _router: Router,
     private _env: EnvironmentsService,
     private _authService: AuthService
   ) {
-    this.subscription.add(this._context.userContext$.subscribe(context => this.context = context));
+    this.subscription.add(this._userContextService.context$.subscribe(context => this.context = context));
     this.subscription.add(this._transactionsService.getBroadcastedTransactions$().subscribe(txs => this.pendingTransactions = txs));
     this.latestSyncedBlock$ = this._indexService.latestBlock$;
 
@@ -68,7 +68,7 @@ export class SideNavComponent implements OnDestroy {
   }
 
   logout(): void {
-    this._context.remove();
+    this._userContextService.remove();
     this._router.navigateByUrl('/');
     this.emitRouteChange('/');
   }

--- a/src/app/components/navigation-module/side-nav/side-nav.component.ts
+++ b/src/app/components/navigation-module/side-nav/side-nav.component.ts
@@ -68,7 +68,7 @@ export class SideNavComponent implements OnDestroy {
   }
 
   logout(): void {
-    this._context.setToken('');
+    this._context.logout();
     this._router.navigateByUrl('/');
     this.emitRouteChange('/');
   }

--- a/src/app/components/navigation-module/side-nav/side-nav.component.ts
+++ b/src/app/components/navigation-module/side-nav/side-nav.component.ts
@@ -41,7 +41,7 @@ export class SideNavComponent implements OnDestroy {
     private _env: EnvironmentsService,
     private _authService: AuthService
   ) {
-    this.subscription.add(this._context.getUserContext$().subscribe(context => this.context = context));
+    this.subscription.add(this._context.userContext$.subscribe(context => this.context = context));
     this.subscription.add(this._transactionsService.getBroadcastedTransactions$().subscribe(txs => this.pendingTransactions = txs));
     this.latestSyncedBlock$ = this._indexService.latestBlock$;
 

--- a/src/app/components/shared-module/theme-toggle/theme-toggle.component.ts
+++ b/src/app/components/shared-module/theme-toggle/theme-toggle.component.ts
@@ -22,10 +22,10 @@ export class ThemeToggleComponent implements OnDestroy {
   }
 
   constructor(
-    private _context: UserContextService,
+    private _userContextService: UserContextService,
     private _theme: ThemeService,
   ) {
-    this.subscription.add(this._context.userContext$.subscribe(context => this.wallet = context));
+    this.subscription.add(this._userContextService.context$.subscribe(context => this.wallet = context));
     this.subscription.add(
       this._theme.getTheme()
         .subscribe(theme => {
@@ -49,7 +49,7 @@ export class ThemeToggleComponent implements OnDestroy {
         if (!preferences) preferences = new UserContextPreferences();
 
         preferences.theme = theme;
-        this._context.setUserPreferences(wallet, preferences);
+        this._userContextService.setUserPreferences(wallet, preferences);
       }
     }
   }

--- a/src/app/components/shared-module/theme-toggle/theme-toggle.component.ts
+++ b/src/app/components/shared-module/theme-toggle/theme-toggle.component.ts
@@ -25,7 +25,7 @@ export class ThemeToggleComponent implements OnDestroy {
     private _context: UserContextService,
     private _theme: ThemeService,
   ) {
-    this.subscription.add(this._context.getUserContext$().subscribe(context => this.wallet = context));
+    this.subscription.add(this._context.userContext$.subscribe(context => this.wallet = context));
     this.subscription.add(
       this._theme.getTheme()
         .subscribe(theme => {

--- a/src/app/components/shared-module/tx-quote-submit-button/tx-quote-submit-button.component.ts
+++ b/src/app/components/shared-module/tx-quote-submit-button/tx-quote-submit-button.component.ts
@@ -29,13 +29,13 @@ export class TxQuoteSubmitButtonComponent implements OnDestroy {
   subscription = new Subscription();
 
   constructor(
-    private _context: UserContextService,
+    private _userContextService: UserContextService,
     private _indexService: IndexService,
     private _dialog: MatDialog,
     private _authService: AuthService
   ) {
     this.subscription.add(
-      this._context.userContext$
+      this._userContextService.context$
         .subscribe(context => this.context = context));
 
     this.subscription.add(

--- a/src/app/components/shared-module/tx-quote-submit-button/tx-quote-submit-button.component.ts
+++ b/src/app/components/shared-module/tx-quote-submit-button/tx-quote-submit-button.component.ts
@@ -44,7 +44,7 @@ export class TxQuoteSubmitButtonComponent implements OnDestroy {
   }
 
   login(): void {
-    this._authService.login();
+    this._authService.prepareLogin();
   }
 
   submit(): void {

--- a/src/app/components/shared-module/tx-quote-submit-button/tx-quote-submit-button.component.ts
+++ b/src/app/components/shared-module/tx-quote-submit-button/tx-quote-submit-button.component.ts
@@ -35,7 +35,7 @@ export class TxQuoteSubmitButtonComponent implements OnDestroy {
     private _authService: AuthService
   ) {
     this.subscription.add(
-      this._context.getUserContext$()
+      this._context.userContext$
         .subscribe(context => this.context = context));
 
     this.subscription.add(

--- a/src/app/components/tables-module/vault-proposal-pledges-table/vault-proposal-pledges-table.component.ts
+++ b/src/app/components/tables-module/vault-proposal-pledges-table/vault-proposal-pledges-table.component.ts
@@ -56,7 +56,7 @@ export class VaultProposalPledgesTableComponent implements OnChanges, OnDestroy 
           .subscribe(_ => this.loading = false));
 
       this.subscription.add(
-        this._userContext.userContext$
+        this._userContext.context$
           .subscribe(context => this.context = context));
     }
 

--- a/src/app/components/tables-module/vault-proposal-pledges-table/vault-proposal-pledges-table.component.ts
+++ b/src/app/components/tables-module/vault-proposal-pledges-table/vault-proposal-pledges-table.component.ts
@@ -56,7 +56,7 @@ export class VaultProposalPledgesTableComponent implements OnChanges, OnDestroy 
           .subscribe(_ => this.loading = false));
 
       this.subscription.add(
-        this._userContext.getUserContext$()
+        this._userContext.userContext$
           .subscribe(context => this.context = context));
     }
 

--- a/src/app/components/tables-module/vault-proposal-votes-table/vault-proposal-votes-table.component.ts
+++ b/src/app/components/tables-module/vault-proposal-votes-table/vault-proposal-votes-table.component.ts
@@ -56,7 +56,7 @@ export class VaultProposalVotesTableComponent implements OnChanges, OnDestroy {
           .subscribe(_ => this.loading = false));
 
       this.subscription.add(
-        this._userContext.getUserContext$()
+        this._userContext.userContext$
           .subscribe(context => this.context = context));
     }
 

--- a/src/app/components/tables-module/vault-proposal-votes-table/vault-proposal-votes-table.component.ts
+++ b/src/app/components/tables-module/vault-proposal-votes-table/vault-proposal-votes-table.component.ts
@@ -56,7 +56,7 @@ export class VaultProposalVotesTableComponent implements OnChanges, OnDestroy {
           .subscribe(_ => this.loading = false));
 
       this.subscription.add(
-        this._userContext.userContext$
+        this._userContext.context$
           .subscribe(context => this.context = context));
     }
 

--- a/src/app/components/tables-module/vault-proposals-table/vault-proposals-table.component.ts
+++ b/src/app/components/tables-module/vault-proposals-table/vault-proposals-table.component.ts
@@ -74,7 +74,7 @@ export class VaultProposalsTableComponent implements OnChanges, OnDestroy {
           .subscribe(_ => this.loading = false));
 
       this.subscription.add(
-        this._userContext.getUserContext$()
+        this._userContext.userContext$
           .subscribe(context => this.context = context));
     }
   }

--- a/src/app/components/tables-module/vault-proposals-table/vault-proposals-table.component.ts
+++ b/src/app/components/tables-module/vault-proposals-table/vault-proposals-table.component.ts
@@ -74,7 +74,7 @@ export class VaultProposalsTableComponent implements OnChanges, OnDestroy {
           .subscribe(_ => this.loading = false));
 
       this.subscription.add(
-        this._userContext.userContext$
+        this._userContext.context$
           .subscribe(context => this.context = context));
     }
   }

--- a/src/app/components/tables-module/wallet-balances-table/wallet-balances-table.component.ts
+++ b/src/app/components/tables-module/wallet-balances-table/wallet-balances-table.component.ts
@@ -17,7 +17,7 @@ import { SidenavService } from '@sharedServices/utility/sidenav.service';
 import { FixedDecimal } from '@sharedModels/types/fixed-decimal';
 import { Icons } from 'src/app/enums/icons';
 import { IconSizes } from 'src/app/enums/icon-sizes';
-import { of, Observable, forkJoin, Subscription } from 'rxjs';
+import { of, Observable, forkJoin, Subscription, lastValueFrom } from 'rxjs';
 import { switchMap, catchError, take, map } from 'rxjs/operators';
 import { ICursor } from '@sharedModels/platform-api/responses/cursor.interface';
 import { WalletBalancesFilter } from '@sharedModels/platform-api/requests/wallets/wallet-balances-filter';
@@ -109,7 +109,7 @@ export class WalletBalancesTableComponent implements OnChanges, OnDestroy {
       return item;
     });
 
-    await this._walletsService.refreshBalance(wallet, token).toPromise();
+    await lastValueFrom(this._walletsService.refreshBalance(wallet, token));
   }
 
   private getWalletBalances$(cursor?: string): Observable<any> {

--- a/src/app/components/tables-module/wallet-balances-table/wallet-balances-table.component.ts
+++ b/src/app/components/tables-module/wallet-balances-table/wallet-balances-table.component.ts
@@ -99,7 +99,7 @@ export class WalletBalancesTableComponent implements OnChanges, OnDestroy {
   }
 
   async refreshBalance(token: string): Promise<void> {
-    const {wallet} = this._userContext.getUserContext();
+    const {wallet} = this._userContext.userContext;
 
     this.dataSource.data = this.dataSource.data.map(item => {
       if (item.token.address === token) {
@@ -113,7 +113,7 @@ export class WalletBalancesTableComponent implements OnChanges, OnDestroy {
   }
 
   private getWalletBalances$(cursor?: string): Observable<any> {
-    const context = this._userContext.getUserContext();
+    const context = this._userContext.userContext;
     if (!!context.wallet === false) return of(null);
 
     this.filter.cursor = cursor;

--- a/src/app/components/tables-module/wallet-mining-positions-table/wallet-mining-positions-table.component.ts
+++ b/src/app/components/tables-module/wallet-mining-positions-table/wallet-mining-positions-table.component.ts
@@ -15,7 +15,7 @@ import { LiquidityPoolsService } from '@sharedServices/platform/liquidity-pools.
 import { WalletsService } from '@sharedServices/platform/wallets.service';
 import { SidenavService } from '@sharedServices/utility/sidenav.service';
 import { UserContextService } from '@sharedServices/utility/user-context.service';
-import { Subscription, of, Observable, forkJoin } from 'rxjs';
+import { Subscription, of, Observable, forkJoin, lastValueFrom } from 'rxjs';
 import { map, switchMap, take } from 'rxjs/operators';
 import { IconSizes } from 'src/app/enums/icon-sizes';
 import { Icons } from 'src/app/enums/icons';
@@ -93,7 +93,7 @@ export class WalletMiningPositionsTableComponent implements OnChanges, OnDestroy
       return item;
     });
 
-    await this._walletsService.refreshMiningPosition(wallet, miningPoolAddress).toPromise();
+    await lastValueFrom(this._walletsService.refreshMiningPosition(wallet, miningPoolAddress));
   }
 
   private getMiningPositions$(cursor?: string): Observable<any> {

--- a/src/app/components/tables-module/wallet-mining-positions-table/wallet-mining-positions-table.component.ts
+++ b/src/app/components/tables-module/wallet-mining-positions-table/wallet-mining-positions-table.component.ts
@@ -83,7 +83,7 @@ export class WalletMiningPositionsTableComponent implements OnChanges, OnDestroy
   }
 
   async refreshPosition(liquidityPoolAddress: string, miningPoolAddress: string): Promise<void> {
-    const {wallet} = this._userContext.getUserContext();
+    const {wallet} = this._userContext.userContext;
 
     this.dataSource.data = this.dataSource.data.map(item => {
       if (item.liquidityPoolAddress === liquidityPoolAddress) {
@@ -97,7 +97,7 @@ export class WalletMiningPositionsTableComponent implements OnChanges, OnDestroy
   }
 
   private getMiningPositions$(cursor?: string): Observable<any> {
-    const context = this._userContext.getUserContext();
+    const context = this._userContext.userContext;
     if (!!context.wallet === false) return of(null);
 
     this.filter.cursor = cursor;

--- a/src/app/components/tables-module/wallet-provisioning-positions-table/wallet-provisioning-positions-table.component.ts
+++ b/src/app/components/tables-module/wallet-provisioning-positions-table/wallet-provisioning-positions-table.component.ts
@@ -14,7 +14,7 @@ import { IndexService } from "@sharedServices/platform/index.service";
 import { WalletsService } from "@sharedServices/platform/wallets.service";
 import { SidenavService } from "@sharedServices/utility/sidenav.service";
 import { UserContextService } from "@sharedServices/utility/user-context.service";
-import { Subscription, Observable, of, forkJoin } from "rxjs";
+import { Subscription, Observable, of, forkJoin, lastValueFrom } from "rxjs";
 import { switchMap, take, map } from "rxjs/operators";
 import { IconSizes } from "src/app/enums/icon-sizes";
 import { Icons } from "src/app/enums/icons";
@@ -92,7 +92,7 @@ export class WalletProvisioningPositionsTableComponent implements OnChanges, OnD
       return item;
     });
 
-    await this._walletsService.refreshBalance(wallet, pool).toPromise();
+    await lastValueFrom(this._walletsService.refreshBalance(wallet, pool));
   }
 
   private getProvisionalPositions$(cursor?: string): Observable<any> {

--- a/src/app/components/tables-module/wallet-provisioning-positions-table/wallet-provisioning-positions-table.component.ts
+++ b/src/app/components/tables-module/wallet-provisioning-positions-table/wallet-provisioning-positions-table.component.ts
@@ -82,7 +82,7 @@ export class WalletProvisioningPositionsTableComponent implements OnChanges, OnD
   }
 
   async refreshBalance(pool: string): Promise<void> {
-    const {wallet} = this._userContext.getUserContext();
+    const {wallet} = this._userContext.userContext;
 
     this.dataSource.data = this.dataSource.data.map(item => {
       if (item.pool.address === pool) {
@@ -96,7 +96,7 @@ export class WalletProvisioningPositionsTableComponent implements OnChanges, OnD
   }
 
   private getProvisionalPositions$(cursor?: string): Observable<any> {
-    const context = this._userContext.getUserContext();
+    const context = this._userContext.userContext;
     if (!!context.wallet === false) return of(null);
 
     this.filter.cursor = cursor;

--- a/src/app/components/tables-module/wallet-staking-positions-table/wallet-staking-positions-table.component.ts
+++ b/src/app/components/tables-module/wallet-staking-positions-table/wallet-staking-positions-table.component.ts
@@ -83,7 +83,7 @@ export class WalletStakingPositionsTableComponent implements OnChanges, OnDestro
   }
 
   async refreshPosition(liquidityPoolAddress: string): Promise<void> {
-    const {wallet} = this._userContext.getUserContext();
+    const {wallet} = this._userContext.userContext;
 
     this.dataSource.data = this.dataSource.data.map(item => {
       if (item.liquidityPoolAddress === liquidityPoolAddress) {
@@ -97,7 +97,7 @@ export class WalletStakingPositionsTableComponent implements OnChanges, OnDestro
   }
 
   private getStakingPositions$(cursor?: string): Observable<any> {
-    const context = this._userContext.getUserContext();
+    const context = this._userContext.userContext;
     if (!!context.wallet === false) return of(null);
 
     this.filter.cursor = cursor;

--- a/src/app/components/tables-module/wallet-staking-positions-table/wallet-staking-positions-table.component.ts
+++ b/src/app/components/tables-module/wallet-staking-positions-table/wallet-staking-positions-table.component.ts
@@ -16,7 +16,7 @@ import { ICursor } from '@sharedModels/platform-api/responses/cursor.interface';
 import { IndexService } from '@sharedServices/platform/index.service';
 import { WalletsService } from '@sharedServices/platform/wallets.service';
 import { UserContextService } from '@sharedServices/utility/user-context.service';
-import { Subscription, of, Observable, forkJoin } from 'rxjs';
+import { Subscription, of, Observable, forkJoin, lastValueFrom } from 'rxjs';
 import { switchMap, take, map } from 'rxjs/operators';
 import { LiquidityPool } from '@sharedModels/ui/liquidity-pools/liquidity-pool';
 
@@ -93,7 +93,7 @@ export class WalletStakingPositionsTableComponent implements OnChanges, OnDestro
       return item;
     });
 
-    await this._walletsService.refreshStakingPosition(wallet, liquidityPoolAddress).toPromise();
+    await lastValueFrom(this._walletsService.refreshStakingPosition(wallet, liquidityPoolAddress));
   }
 
   private getStakingPositions$(cursor?: string): Observable<any> {

--- a/src/app/components/tx-module/shared/percentage-amount-buttons/percentage-amount-buttons.component.ts
+++ b/src/app/components/tx-module/shared/percentage-amount-buttons/percentage-amount-buttons.component.ts
@@ -31,13 +31,13 @@ export class PercentageAmountButtonsComponent implements OnChanges {
   percentages: string[] = [ '25', '50', '75', '100' ];
 
   constructor(
-    private _context: UserContextService,
+    private _userContextService: UserContextService,
     private _indexService: IndexService,
     private _walletService: WalletsService,
     private _vaultService: VaultsService
   ) {
     this.contextSubscription.add(
-      this._context.userContext$
+      this._userContextService.context$
         .pipe(tap(context => this.context = context))
         .subscribe(_ => this.ngOnChanges()));
   }

--- a/src/app/components/tx-module/shared/percentage-amount-buttons/percentage-amount-buttons.component.ts
+++ b/src/app/components/tx-module/shared/percentage-amount-buttons/percentage-amount-buttons.component.ts
@@ -37,7 +37,7 @@ export class PercentageAmountButtonsComponent implements OnChanges {
     private _vaultService: VaultsService
   ) {
     this.contextSubscription.add(
-      this._context.getUserContext$()
+      this._context.userContext$
         .pipe(tap(context => this.context = context))
         .subscribe(_ => this.ngOnChanges()));
   }

--- a/src/app/components/tx-module/shared/review-quote/review-quote.component.ts
+++ b/src/app/components/tx-module/shared/review-quote/review-quote.component.ts
@@ -1,10 +1,9 @@
-import { EnvironmentsService } from '@sharedServices/utility/environments.service';
 import { IndexService } from '@sharedServices/platform/index.service';
 import { IBlock } from '@sharedModels/platform-api/responses/blocks/block.interface';
 import { ITransactionReceipt } from '@sharedModels/platform-api/responses/transactions/transaction.interface';
 import { TransactionReceipt } from '@sharedModels/ui/transactions/transaction-receipt';
 import { TransactionsService } from '@sharedServices/platform/transactions.service';
-import { filter, switchMap } from 'rxjs/operators';
+import { filter, switchMap, skip } from 'rxjs/operators';
 import { tap } from 'rxjs/operators';
 import { Component, Inject, OnDestroy } from '@angular/core';
 import { MatBottomSheetRef, MAT_BOTTOM_SHEET_DATA } from '@angular/material/bottom-sheet';
@@ -51,7 +50,6 @@ export class ReviewQuoteComponent implements OnDestroy {
     public _bottomSheetRef: MatBottomSheetRef<ReviewQuoteComponent>,
     private _transactionsService: TransactionsService,
     private _indexService: IndexService,
-    private _env: EnvironmentsService,
     @Inject(MAT_BOTTOM_SHEET_DATA) public data: ITransactionQuote
   ) {
     this.quote = this.data;
@@ -87,6 +85,7 @@ export class ReviewQuoteComponent implements OnDestroy {
     this.subscription.add(
       this._indexService.latestBlock$
         .pipe(
+          skip(1),
           tap(block => this.latestBlock = block),
           filter(_ => !!this.txHash === false),
           switchMap(_ => this._platformApi.replayQuote(new TransactionQuoteRequest(this.data.request).payload)),

--- a/src/app/components/tx-module/shared/wallet-preview/wallet-preview.component.ts
+++ b/src/app/components/tx-module/shared/wallet-preview/wallet-preview.component.ts
@@ -45,7 +45,7 @@ export class WalletPreviewComponent implements OnDestroy {
     private _indexService: IndexService,
     private _miningPoolService: MiningPoolsService
   ) {
-    this.subscription.add(this._userContext.userContext$
+    this.subscription.add(this._userContext.context$
       .pipe(
         tap(context => this.context = context),
         switchMap(_ => this.getWalletSummary()))

--- a/src/app/components/tx-module/shared/wallet-preview/wallet-preview.component.ts
+++ b/src/app/components/tx-module/shared/wallet-preview/wallet-preview.component.ts
@@ -45,7 +45,7 @@ export class WalletPreviewComponent implements OnDestroy {
     private _indexService: IndexService,
     private _miningPoolService: MiningPoolsService
   ) {
-    this.subscription.add(this._userContext.getUserContext$()
+    this.subscription.add(this._userContext.userContext$
       .pipe(
         tap(context => this.context = context),
         switchMap(_ => this.getWalletSummary()))

--- a/src/app/components/tx-module/tx-base.component.ts
+++ b/src/app/components/tx-module/tx-base.component.ts
@@ -30,7 +30,7 @@ export abstract class TxBase {
     this._bottomSheet = this._injector.get(MatBottomSheet);
     this._walletsService = this._injector.get(WalletsService);
     this._vaultsService = this._injector.get(VaultsService);
-    this.context$ = this._userContext.userContext$.subscribe(context => this.context = context);
+    this.context$ = this._userContext.context$.subscribe(context => this.context = context);
   }
 
   quote(quote: ITransactionQuote): void {

--- a/src/app/components/tx-module/tx-base.component.ts
+++ b/src/app/components/tx-module/tx-base.component.ts
@@ -30,7 +30,7 @@ export abstract class TxBase {
     this._bottomSheet = this._injector.get(MatBottomSheet);
     this._walletsService = this._injector.get(WalletsService);
     this._vaultsService = this._injector.get(VaultsService);
-    this.context$ = this._userContext.getUserContext$().subscribe(context => this.context = context);
+    this.context$ = this._userContext.userContext$.subscribe(context => this.context = context);
   }
 
   quote(quote: ITransactionQuote): void {

--- a/src/app/components/tx-module/tx-sidebar/tx-sidebar.component.ts
+++ b/src/app/components/tx-module/tx-sidebar/tx-sidebar.component.ts
@@ -43,7 +43,7 @@ export class TxSidebarComponent implements OnChanges {
       : [...TransactionTypes.filter(type => !!type.view && type.view !== TransactionView.vaultProposal)]
 
     this.subscription.add(
-      this._context.getUserContext$()
+      this._context.userContext$
         .subscribe(context => {
           this.context = context;
 

--- a/src/app/components/tx-module/tx-sidebar/tx-sidebar.component.ts
+++ b/src/app/components/tx-module/tx-sidebar/tx-sidebar.component.ts
@@ -35,7 +35,7 @@ export class TxSidebarComponent implements OnChanges {
   constructor(
     private _breakpointObserver: BreakpointObserver,
     private _sidenav: SidenavService,
-    private _context: UserContextService,
+    private _userContextService: UserContextService,
     private _env: EnvironmentsService
   ) {
     this.transactionTypes = !!this._env.vaultAddress
@@ -43,7 +43,7 @@ export class TxSidebarComponent implements OnChanges {
       : [...TransactionTypes.filter(type => !!type.view && type.view !== TransactionView.vaultProposal)]
 
     this.subscription.add(
-      this._context.userContext$
+      this._userContextService.context$
         .subscribe(context => {
           this.context = context;
 

--- a/src/app/enums/auth-grant-types.ts
+++ b/src/app/enums/auth-grant-types.ts
@@ -1,0 +1,4 @@
+export enum AuthGrantTypes {
+  AuthorizationCode = 'authorization_code',
+  RefreshToken = 'refresh_token'
+}

--- a/src/app/models/auth-api/auth-request.ts
+++ b/src/app/models/auth-api/auth-request.ts
@@ -1,0 +1,24 @@
+import { AuthGrantTypes } from "src/app/enums/auth-grant-types";
+
+export class AuthRequest {
+  private _request: URLSearchParams;
+
+  get request(): URLSearchParams {
+    return this._request;
+  }
+
+  constructor(code?: string, codeVerifier?: string, refreshToken?: string) {
+    const request = new URLSearchParams();
+    const grantType = refreshToken ? AuthGrantTypes.RefreshToken : AuthGrantTypes.AuthorizationCode;
+
+    request.set('grantType', grantType);
+    if (grantType === AuthGrantTypes.AuthorizationCode) {
+      request.set('code', code);
+      request.set('codeVerifier', codeVerifier);
+    } else {
+      request.set('refreshToken', refreshToken);
+    }
+
+    this._request = request;
+  }
+}

--- a/src/app/models/auth-api/auth-request.ts
+++ b/src/app/models/auth-api/auth-request.ts
@@ -8,10 +8,11 @@ export class AuthRequest {
   }
 
   constructor(code?: string, codeVerifier?: string, refreshToken?: string) {
-    const request = new URLSearchParams();
     const grantType = refreshToken ? AuthGrantTypes.RefreshToken : AuthGrantTypes.AuthorizationCode;
+    const request = new URLSearchParams();
 
     request.set('grantType', grantType);
+
     if (grantType === AuthGrantTypes.AuthorizationCode) {
       request.set('code', code);
       request.set('codeVerifier', codeVerifier);

--- a/src/app/models/auth-api/auth-response.interface.ts
+++ b/src/app/models/auth-api/auth-response.interface.ts
@@ -1,6 +1,6 @@
 export interface IAuthResponse {
-  accessToken: string;
-  tokenType: string;
-  expiresIn: number;
-  refreshToken: string;
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  refresh_token: string;
 }

--- a/src/app/models/auth-api/auth-response.interface.ts
+++ b/src/app/models/auth-api/auth-response.interface.ts
@@ -1,0 +1,6 @@
+export interface IAuthResponse {
+  accessToken: string;
+  tokenType: string;
+  expiresIn: number;
+  refreshToken: string;
+}

--- a/src/app/models/auth-api/jwt.ts
+++ b/src/app/models/auth-api/jwt.ts
@@ -1,0 +1,9 @@
+export type JWT = {
+  wallet: string,
+  sub: string,
+  nbf: number,
+  exp: number,
+  iat: number,
+  iss: string,
+  aud: string
+}

--- a/src/app/services/api/auth-api.service.ts
+++ b/src/app/services/api/auth-api.service.ts
@@ -1,6 +1,8 @@
 import { HttpClient, HttpHeaders } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { Router } from "@angular/router";
+import { AuthRequest } from "@sharedModels/auth-api/auth-request";
+import { IAuthResponse } from "@sharedModels/auth-api/auth-response.interface";
 import { EnvironmentsService } from "@sharedServices/utility/environments.service";
 import { ErrorService } from "@sharedServices/utility/error.service";
 import { JwtService } from "@sharedServices/utility/jwt.service";
@@ -24,16 +26,12 @@ export class AuthApiService extends RestApiService {
     this.api = this._env.authApiUrl;
   }
 
-  public verifyAccessCode(code: string, codeVerifier: string): Observable<string> {
+  public auth(request: AuthRequest): Observable<IAuthResponse> {
     const endpoint = `${this.api}/auth/token`;
     const headers = new HttpHeaders()
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .set('Accept', 'text');
 
-    const body = new URLSearchParams();
-    body.set('code', code);
-    body.set('codeVerifier', codeVerifier);
-
-    return this.post<string>(endpoint, body, { headers });
+    return this.post<IAuthResponse>(endpoint, request, { headers });
   }
 }

--- a/src/app/services/api/auth-api.service.ts
+++ b/src/app/services/api/auth-api.service.ts
@@ -27,11 +27,7 @@ export class AuthApiService extends RestApiService {
   }
 
   public auth(request: AuthRequest): Observable<IAuthResponse> {
-    const endpoint = `${this.api}/auth/token`;
-    const headers = new HttpHeaders()
-      .set('Content-Type', 'application/x-www-form-urlencoded')
-      .set('Accept', 'text');
-
-    return this.post<IAuthResponse>(endpoint, request, { headers });
+    const headers = new HttpHeaders({' Content-Type': 'application/x-www-form-urlencoded'});
+    return this.post<IAuthResponse>(`${this.api}/auth/token`, request, { headers });
   }
 }

--- a/src/app/services/api/auth-api.service.ts
+++ b/src/app/services/api/auth-api.service.ts
@@ -26,8 +26,11 @@ export class AuthApiService extends RestApiService {
     this.api = this._env.authApiUrl;
   }
 
-  public auth(request: AuthRequest): Observable<IAuthResponse> {
-    const headers = new HttpHeaders({' Content-Type': 'application/x-www-form-urlencoded'});
+  public auth({ request }: AuthRequest): Observable<IAuthResponse> {
+    const headers = new HttpHeaders()
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .set('Accept', 'application/json');
+
     return this.post<IAuthResponse>(`${this.api}/auth/token`, request, { headers });
   }
 }

--- a/src/app/services/api/auth.interceptor.ts
+++ b/src/app/services/api/auth.interceptor.ts
@@ -16,8 +16,9 @@ export class AuthInterceptor implements HttpInterceptor {
           // -- if token - use refresh token
           // ------------- set new access / refresh tokens
           // ------------- retry request
-          // return this._authService.refresh().pipe(switchMap(_ => next.handle(req)));
           console.log(`401 in interceptor`);
+          return this._authService.refresh()
+            .pipe(switchMap(_ => next.handle(req)));
         }
 
         return throwError(error);

--- a/src/app/services/api/auth.interceptor.ts
+++ b/src/app/services/api/auth.interceptor.ts
@@ -1,0 +1,26 @@
+import { AuthService } from '@sharedServices/utility/auth.service';
+import { HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from "@angular/common/http";
+import { Injectable } from "@angular/core";
+import { catchError, Observable, switchMap, throwError } from "rxjs";
+
+@Injectable()
+export class AuthInterceptor implements HttpInterceptor {
+  constructor(private _authService: AuthService) { }
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    return next.handle(req)
+      .pipe(catchError(error => {
+        if (error instanceof HttpErrorResponse && error.status === 401) {
+          // handle error
+          // try get token
+          // -- if token - use refresh token
+          // ------------- set new access / refresh tokens
+          // ------------- retry request
+          // return this._authService.refresh().pipe(switchMap(_ => next.handle(req)));
+          console.log(`401 in interceptor`);
+        }
+
+        return throwError(error);
+      }));
+  }
+}

--- a/src/app/services/api/rest-api.service.ts
+++ b/src/app/services/api/rest-api.service.ts
@@ -55,20 +55,17 @@ export class RestApiService {
 
   protected put<T>(endpoint: string, payload: any, options: object = {}): Observable<T> {
     return this._http.put<T>(endpoint, payload, options)
-      .pipe(
-        catchError(error => this.handleError(error)));
+      .pipe(catchError(error => this.handleError(error)));
   }
 
   protected patch<T>(endpoint: string, payload: any, options: object = {}): Observable<T> {
     return this._http.patch<T>(endpoint, payload, options)
-      .pipe(
-        catchError(error => this.handleError(error)));
+      .pipe(catchError(error => this.handleError(error)));
   }
 
   protected delete<T>(endpoint: string, options: object = {}): Observable<T> {
     return this._http.delete<T>(endpoint, options)
-      .pipe(
-        catchError(error => this.handleError(error)));
+      .pipe(catchError(error => this.handleError(error)));
   }
 
   private handleError(error: HttpErrorResponse) {

--- a/src/app/services/api/rest-api.service.ts
+++ b/src/app/services/api/rest-api.service.ts
@@ -74,7 +74,7 @@ export class RestApiService {
       console.error('An error occurred:', error.error);
     } else if (error.status === 401) {
       // Todo: Use refresh token and retry request
-      this._context.setToken('');
+      this._context.remove();
     }
 
     const errors = [];

--- a/src/app/services/api/rest-api.service.ts
+++ b/src/app/services/api/rest-api.service.ts
@@ -76,6 +76,7 @@ export class RestApiService {
       // A client-side or network error occurred. Handle it accordingly.
       console.error('An error occurred:', error.error);
     } else if (error.status === 401) {
+      // Todo: Use refresh token and retry request
       this._context.setToken('');
     }
 

--- a/src/app/services/api/rest-api.service.ts
+++ b/src/app/services/api/rest-api.service.ts
@@ -72,8 +72,7 @@ export class RestApiService {
     if (error.status === 0) {
       // A client-side or network error occurred. Handle it accordingly.
       console.error('An error occurred:', error.error);
-    } else if (error.status === 401) {
-      // Todo: Use refresh token and retry request
+    } else if (error.status === 403) {
       this._context.remove();
     }
 

--- a/src/app/services/api/rest-api.service.ts
+++ b/src/app/services/api/rest-api.service.ts
@@ -22,7 +22,7 @@ export class RestApiService {
     protected _http: HttpClient,
     protected _error: ErrorService,
     protected _jwt: JwtService,
-    protected _context: UserContextService,
+    protected _userContextService: UserContextService,
     protected _router: Router,
     protected _env: EnvironmentsService
   ) { }
@@ -73,7 +73,7 @@ export class RestApiService {
       // A client-side or network error occurred. Handle it accordingly.
       console.error('An error occurred:', error.error);
     } else if (error.status === 403) {
-      this._context.remove();
+      this._userContextService.remove();
     }
 
     const errors = [];

--- a/src/app/services/guards/auth.guard.ts
+++ b/src/app/services/guards/auth.guard.ts
@@ -42,7 +42,7 @@ export class AuthGuard implements CanActivate, CanActivateChild, CanLoad {
    */
   private authorize(): boolean {
     // Validate the users JWT
-    // if (!this._context.getUserContext()?.wallet) {
+    // if (!this._context.userContext?.wallet) {
     //   return this.fail();
     // }
 

--- a/src/app/services/guards/auth.guard.ts
+++ b/src/app/services/guards/auth.guard.ts
@@ -7,7 +7,7 @@ import { environment } from '@environments/environment';
 @Injectable({ providedIn: 'root' })
 export class AuthGuard implements CanActivate, CanActivateChild, CanLoad {
   constructor(
-    private _context: UserContextService,
+    private _userContextService: UserContextService,
     private _router: Router,
     private _env: EnvironmentsService
   ) { }
@@ -42,7 +42,7 @@ export class AuthGuard implements CanActivate, CanActivateChild, CanLoad {
    */
   private authorize(): boolean {
     // Validate the users JWT
-    // if (!this._context.userContext?.wallet) {
+    // if (!this._userContextService.userContext?.wallet) {
     //   return this.fail();
     // }
 

--- a/src/app/services/jwt-options-factory.ts
+++ b/src/app/services/jwt-options-factory.ts
@@ -1,0 +1,8 @@
+import { JwtService } from "./utility/jwt.service";
+
+export function jwtOptionsFactory(jwtService: JwtService) {
+  return {
+    tokenGetter: () => jwtService.accessToken,
+    allowedDomains: [...jwtService.allowedDomains]
+  }
+}

--- a/src/app/services/utility/auth.service.ts
+++ b/src/app/services/utility/auth.service.ts
@@ -1,3 +1,5 @@
+import { IAuthResponse } from '@sharedModels/auth-api/auth-response.interface';
+import { AuthRequest } from '@sharedModels/auth-api/auth-request';
 import { AuthVerification } from '@sharedModels/ui/auth-verification';
 import { UserContextService } from './user-context.service';
 import { AuthApiService } from '@sharedServices/api/auth-api.service';
@@ -7,6 +9,7 @@ import { Injectable } from "@angular/core";
 import { v4 as uuidv4 } from 'uuid';
 import pkceChallenge from "pkce-challenge";
 import { encode, decode } from 'url-safe-base64'
+import { Observable } from 'rxjs';
 
 
 const AUTH_STATE: string = 'auth-state';
@@ -43,9 +46,10 @@ export class AuthService {
     if (stateEncoded !== state) return new AuthVerification({error: `Invalid state!`});
 
     try {
-      const token = await this._authApi.verifyAccessCode(accessCode, codeVerifier).toPromise();
+      const request = new AuthRequest(accessCode, codeVerifier);
+      const token = await this._authApi.auth(request).toPromise();
 
-      this._context.setToken(token);
+      this._context.setToken(token.accessToken);
       this._storage.removeLocalStorage(AUTH_STATE);
       this._storage.removeLocalStorage(CODE_VERIFIER);
 
@@ -53,5 +57,12 @@ export class AuthService {
     } catch(error) {
       return new AuthVerification({error});
     }
+  }
+
+  refresh(): Observable<IAuthResponse> {
+    // Todo: try get refresh token
+    const refreshToken = 'refreshtoken';
+
+    return this._authApi.auth(new AuthRequest(null, null, refreshToken));
   }
 }

--- a/src/app/services/utility/jwt.service.ts
+++ b/src/app/services/utility/jwt.service.ts
@@ -15,7 +15,7 @@ const _jwt = new JwtHelperService();
 
 @Injectable()
 export class JwtService {
-  private storageKey = 'jwt';
+  private _storageKey = 'jwt';
 
   constructor(
     private _storage: StorageService,
@@ -29,7 +29,7 @@ export class JwtService {
   }
 
   /** Decodes the current users JWT */
-  public decodeToken() {
+  public decodeToken(): any {
     const token = this.getToken();
     return _jwt.decodeToken(token);
   }
@@ -51,17 +51,17 @@ export class JwtService {
 
   /** Rets the current JWT from local storage */
   public getToken(): string {
-    return this._storage.getLocalStorage<any>(this.storageKey);
+    return this._storage.getLocalStorage<any>(this._storageKey);
   }
 
   /** Removes the current JWT from local storage */
    public removeToken(): void {
-    this._storage.removeLocalStorage(this.storageKey);
+    this._storage.removeLocalStorage(this._storageKey);
   }
 
   /** Sets the current JWT to local storage */
-   public setToken(data: any): void {
-    this._storage.setLocalStorage(this.storageKey, data);
+   public setToken(data: string): void {
+    this._storage.setLocalStorage(this._storageKey, data);
   }
 
   /** Checks if the current JWT is expired */

--- a/src/app/services/utility/jwt.service.ts
+++ b/src/app/services/utility/jwt.service.ts
@@ -3,6 +3,14 @@ import { Injectable } from '@angular/core';
 import { JwtHelperService } from "@auth0/angular-jwt";
 import { StorageService } from './storage.service';
 
+
+export function jwtOptionsFactory(jwtService: JwtService) {
+  return {
+    tokenGetter: () => jwtService.getToken(),
+    allowedDomains: [...jwtService.allowedDomains]
+  }
+}
+
 const _jwt = new JwtHelperService();
 
 @Injectable()
@@ -15,79 +23,49 @@ export class JwtService {
   ) { }
 
   public get allowedDomains(): string[] {
-    const platformApi = new URL(this._env.platformApiUrl);
-    const authApi = new URL(this._env.authApiUrl);
-
-    return [platformApi.host, authApi.host];
+    const { host: platformHost } = new URL(this._env.platformApiUrl);
+    const { host: authHost } = new URL(this._env.authApiUrl);
+    return [ platformHost, authHost ];
   }
 
-  /**
-   * Decodes the current users JWT
-   */
+  /** Decodes the current users JWT */
   public decodeToken() {
     const token = this.getToken();
     return _jwt.decodeToken(token);
   }
 
-  /**
-   * Get the expiration date of the current users JWT
-   */
+  /** Get the expiration date of the current users JWT */
   public getTokenExpirationDate(): Date {
     const token = this.getToken();
-
     return _jwt.getTokenExpirationDate(token);
   }
 
   /**
-   * check if a JWT is expired
+   * Checks if a JWT is expired
    * @param offsetSeconds optional offset to check expiration
-   * @returns boolean value
    */
   public isTokenExpired(offsetSeconds?: number): boolean {
     const token = this.getToken();
-
     return _jwt.isTokenExpired(token, offsetSeconds);
   }
 
-  public getTokenSet(): any {
-
-  }
-
-  /**
-   * gets the current JWT from local storage
-   * @returns JWT string
-   */
+  /** Rets the current JWT from local storage */
   public getToken(): string {
     return this._storage.getLocalStorage<any>(this.storageKey);
   }
 
-  /**
-   * removes the current JWT from local storage
-   */
+  /** Removes the current JWT from local storage */
    public removeToken(): void {
     this._storage.removeLocalStorage(this.storageKey);
   }
 
-  /**
-   * sets the current JWT to local storage
-   * @returns JWT string
-   */
+  /** Sets the current JWT to local storage */
    public setToken(data: any): void {
     this._storage.setLocalStorage(this.storageKey, data);
   }
 
-  /**
-   * checks if the current JWT is expired
-   * @returns boolean as success
-   */
+  /** Checks if the current JWT is expired */
   public isAuthorized(): boolean {
     return this.isTokenExpired() === false;
-  }
-}
-
-export function jwtOptionsFactory(jwtService: JwtService) {
-  return {
-    tokenGetter: () => jwtService.getToken(),
-    allowedDomains: [...jwtService.allowedDomains]
   }
 }

--- a/src/app/services/utility/jwt.service.ts
+++ b/src/app/services/utility/jwt.service.ts
@@ -5,6 +5,7 @@ import { JwtHelperService } from "@auth0/angular-jwt";
 import { StorageService } from './storage.service';
 import { JWT } from '@sharedModels/auth-api/jwt';
 const _jwt = new JwtHelperService();
+
 @Injectable()
 export class JwtService {
   private _storageKey = 'refresh';
@@ -27,7 +28,7 @@ export class JwtService {
   }
 
   public get refreshToken(): string {
-    return this._refreshToken || this._storage.getLocalStorage<string>(this._storageKey);
+    return this._refreshToken || this._storage.getLocalStorage<string>(this._storageKey, false);
   }
 
   public get jwt(): JWT {

--- a/src/app/services/utility/jwt.service.ts
+++ b/src/app/services/utility/jwt.service.ts
@@ -28,7 +28,7 @@ export class JwtService {
   }
 
   public get refreshToken(): string {
-    return this._refreshToken || this._storage.getLocalStorage<string>(this._storageKey, false);
+    return this._refreshToken || this._storage.getLocalStorage<string>(this._storageKey);
   }
 
   public get jwt(): JWT {
@@ -39,10 +39,10 @@ export class JwtService {
     return _jwt.isTokenExpired(this.accessToken);
   }
 
-  public set({ accessToken, refreshToken }: IAuthResponse): void {
-    this._accessToken = accessToken;
-    this._refreshToken = refreshToken;
-    this._storage.setLocalStorage(this._storageKey, refreshToken);
+  public set({ access_token, refresh_token }: IAuthResponse): void {
+    this._accessToken = access_token;
+    this._refreshToken = refresh_token;
+    this._storage.setLocalStorage(this._storageKey, refresh_token);
   }
 
   public remove(): void {

--- a/src/app/services/utility/jwt.service.ts
+++ b/src/app/services/utility/jwt.service.ts
@@ -9,7 +9,10 @@ const _jwt = new JwtHelperService();
 export class JwtService {
   private storageKey = 'jwt';
 
-  constructor(private _storage: StorageService, private _env: EnvironmentsService) { }
+  constructor(
+    private _storage: StorageService,
+    private _env: EnvironmentsService
+  ) { }
 
   public get allowedDomains(): string[] {
     const platformApi = new URL(this._env.platformApiUrl);
@@ -19,7 +22,7 @@ export class JwtService {
   }
 
   /**
-   * @summary Decodes the current users JWT
+   * Decodes the current users JWT
    */
   public decodeToken() {
     const token = this.getToken();
@@ -27,7 +30,7 @@ export class JwtService {
   }
 
   /**
-   * @summary Get the expiration date of the current users JWT
+   * Get the expiration date of the current users JWT
    */
   public getTokenExpirationDate(): Date {
     const token = this.getToken();
@@ -36,7 +39,7 @@ export class JwtService {
   }
 
   /**
-   * @summary check if a JWT is expired
+   * check if a JWT is expired
    * @param offsetSeconds optional offset to check expiration
    * @returns boolean value
    */
@@ -46,8 +49,12 @@ export class JwtService {
     return _jwt.isTokenExpired(token, offsetSeconds);
   }
 
+  public getTokenSet(): any {
+
+  }
+
   /**
-   * @summary gets the current JWT from local storage
+   * gets the current JWT from local storage
    * @returns JWT string
    */
   public getToken(): string {
@@ -55,14 +62,14 @@ export class JwtService {
   }
 
   /**
-   * @summary removes the current JWT from local storage
+   * removes the current JWT from local storage
    */
    public removeToken(): void {
     this._storage.removeLocalStorage(this.storageKey);
   }
 
   /**
-   * @summary sets the current JWT to local storage
+   * sets the current JWT to local storage
    * @returns JWT string
    */
    public setToken(data: any): void {
@@ -70,7 +77,7 @@ export class JwtService {
   }
 
   /**
-   * @summary checks if the current JWT is expired
+   * checks if the current JWT is expired
    * @returns boolean as success
    */
   public isAuthorized(): boolean {

--- a/src/app/services/utility/storage.service.ts
+++ b/src/app/services/utility/storage.service.ts
@@ -2,9 +2,7 @@ import { EnvironmentsService } from './environments.service';
 import { Injectable } from '@angular/core';
 import { Network } from 'src/app/enums/networks';
 
-@Injectable({
-  providedIn: 'root'
-})
+@Injectable({ providedIn: 'root' })
 export class StorageService {
   keyPrefix: string;
 
@@ -18,25 +16,21 @@ export class StorageService {
     this.keyPrefix = `odx-${network}-`;
   }
 
-  //
-  // LOCAL STORAGE
-  //
-
   /**
-   * @summary Get a value form local storage based on the provided key
+   * Get a value form local storage based on the provided key
    * @param key The key to search local storage for
    * @param parse Defaults to true, set to false to not parse the value (e.g. expecting a string response)
    */
   getLocalStorage<T>(key: string, parse: boolean = true): T {
     const result = <string>localStorage.getItem(this._storageKey(key));
 
-    return parse === true
+    return parse === true && result
       ? JSON.parse(result)
       : result;
   }
 
   /**
-   * @summary Set a value in local storage based on the provided key and data
+   * Set a value in local storage based on the provided key and data
    * @param key The key to store in local storage by
    * @param data The data to persist
    * @param stringify Defaults to true, can be set to false if the provided data is already a string
@@ -50,32 +44,28 @@ export class StorageService {
   }
 
   /**
-   * @summary Remove an item from local storage
+   * Remove an item from local storage
    * @param key The key to remove from local storage
    */
   removeLocalStorage(key: string): void {
     localStorage.removeItem(this._storageKey(key));
   }
 
-  //
-  // SESSION STORAGE
-  //
-
   /**
-   * @summary Get a value form session storage based on the provided key
+   * Get a value form session storage based on the provided key
    * @param key The key to search session storage for
    * @param parse Defaults to true, set to false to not parse the value (e.g. expecting a string response)
    */
   getSessionStorage<T>(key: string, parse: boolean = true): T {
     const result = <string>sessionStorage.getItem(this._storageKey(key));
 
-    return parse === true
+    return parse === true && result
       ? JSON.parse(result)
       : result;
   }
 
   /**
-   * @summary Set a value in session storage based on the provided key and data
+   * Set a value in session storage based on the provided key and data
    * @param key The key to store in session storage by
    * @param data The data to persist
    * @param stringify Defaults to true, can be set to false if the provided data is already a string
@@ -89,16 +79,12 @@ export class StorageService {
   }
 
   /**
-   * @summary Remove an item from session storage
+   * Remove an item from session storage
    * @param key The key to remove from session storage
    */
   removeSessionStorage(key: string): void {
     sessionStorage.removeItem(this._storageKey(key));
   }
-
-  //
-  // HELPERS
-  //
 
   private _storageKey(key: string): string {
     return `${this.keyPrefix}${key}`;

--- a/src/app/services/utility/storage.service.ts
+++ b/src/app/services/utility/storage.service.ts
@@ -9,18 +9,18 @@ export class StorageService {
   keyPrefix: string;
 
   constructor(private _env: EnvironmentsService) {
-    const isDevnet = this._env.network === Network.Devnet;
-
-    const network = isDevnet
-      ? this._env.network.substring(0, 3).toLowerCase()
-      : this._env.network.substring(0, 4).toLowerCase();
+    const network = this._env.network === Network.Devnet
+      ? 'dev'
+      : this._env.network === Network.Testnet
+        ? 'test'
+        : 'main';
 
     this.keyPrefix = `odx-${network}-`;
   }
 
-  private keyWithPrefix(key: string): string {
-    return `${this.keyPrefix}${key}`;
-  }
+  //
+  // LOCAL STORAGE
+  //
 
   /**
    * @summary Get a value form local storage based on the provided key
@@ -28,7 +28,7 @@ export class StorageService {
    * @param parse Defaults to true, set to false to not parse the value (e.g. expecting a string response)
    */
   getLocalStorage<T>(key: string, parse: boolean = true): T {
-    const result = <string>localStorage.getItem(this.keyWithPrefix(key));
+    const result = <string>localStorage.getItem(this._storageKey(key));
 
     return parse === true
       ? JSON.parse(result)
@@ -46,7 +46,7 @@ export class StorageService {
       ? JSON.stringify(data)
       : data as string;
 
-    localStorage.setItem(this.keyWithPrefix(key), dataString);
+    localStorage.setItem(this._storageKey(key), dataString);
   }
 
   /**
@@ -54,8 +54,12 @@ export class StorageService {
    * @param key The key to remove from local storage
    */
   removeLocalStorage(key: string): void {
-    localStorage.removeItem(this.keyWithPrefix(key));
+    localStorage.removeItem(this._storageKey(key));
   }
+
+  //
+  // SESSION STORAGE
+  //
 
   /**
    * @summary Get a value form session storage based on the provided key
@@ -63,7 +67,7 @@ export class StorageService {
    * @param parse Defaults to true, set to false to not parse the value (e.g. expecting a string response)
    */
   getSessionStorage<T>(key: string, parse: boolean = true): T {
-    const result = <string>sessionStorage.getItem(this.keyWithPrefix(key));
+    const result = <string>sessionStorage.getItem(this._storageKey(key));
 
     return parse === true
       ? JSON.parse(result)
@@ -81,7 +85,7 @@ export class StorageService {
       ? JSON.stringify(data)
       : data as string;
 
-    sessionStorage.setItem(this.keyWithPrefix(key), dataString);
+    sessionStorage.setItem(this._storageKey(key), dataString);
   }
 
   /**
@@ -89,6 +93,14 @@ export class StorageService {
    * @param key The key to remove from session storage
    */
   removeSessionStorage(key: string): void {
-    sessionStorage.removeItem(this.keyWithPrefix(key));
+    sessionStorage.removeItem(this._storageKey(key));
+  }
+
+  //
+  // HELPERS
+  //
+
+  private _storageKey(key: string): string {
+    return `${this.keyPrefix}${key}`;
   }
 }

--- a/src/app/services/utility/theme.service.ts
+++ b/src/app/services/utility/theme.service.ts
@@ -16,7 +16,7 @@ export class ThemeService {
     private _context: UserContextService
   ) {
     const defaultTheme =
-      this._context.getUserContext()?.preferences?.theme ||
+      this._context.userContext?.preferences?.theme ||
       this._db.getLocalStorage<string>(this.themeKey, false) ||
       environment.defaultTheme;
 

--- a/src/app/services/utility/theme.service.ts
+++ b/src/app/services/utility/theme.service.ts
@@ -13,10 +13,10 @@ export class ThemeService {
 
   constructor(
     private _db: StorageService,
-    private _context: UserContextService
+    private _userContextService: UserContextService
   ) {
     const defaultTheme =
-      this._context.userContext?.preferences?.theme ||
+      this._userContextService.userContext?.preferences?.theme ||
       this._db.getLocalStorage<string>(this.themeKey, false) ||
       environment.defaultTheme;
 

--- a/src/app/services/utility/user-context.service.ts
+++ b/src/app/services/utility/user-context.service.ts
@@ -8,15 +8,15 @@ import { Injectable } from '@angular/core';
 @Injectable({ providedIn: 'root' })
 export class UserContextService {
   private _context = new UserContext();
-  private _userContext$ = new BehaviorSubject<UserContext>(this._context);
+  private _context$ = new BehaviorSubject<UserContext>(this._context);
 
   constructor(
     private _jwtService: JwtService,
     private _storage: StorageService
   ) { }
 
-  get userContext$(): Observable<UserContext> {
-    return this._userContext$.asObservable();
+  get context$(): Observable<UserContext> {
+    return this._context$.asObservable();
   }
 
   get accessToken(): string {
@@ -30,18 +30,18 @@ export class UserContextService {
   set(resp: IAuthResponse): void {
     this._jwtService.set(resp);
     this._context = this._buildUserContext();
-    this._userContext$.next(this._context)
+    this._context$.next(this._context)
   }
 
   remove(): void {
     this._jwtService.remove();
     this._context = new UserContext();
-    this._userContext$.next(this._context);
+    this._context$.next(this._context);
   }
 
   setUserPreferences(wallet: string, preferences: UserContextPreferences): void {
     this._storage.setLocalStorage(wallet, preferences, true);
-    this._userContext$.next(this.userContext)
+    this._context$.next(this.userContext)
   }
 
   private _buildUserContext(): UserContext {

--- a/src/app/services/utility/user-context.service.ts
+++ b/src/app/services/utility/user-context.service.ts
@@ -30,7 +30,7 @@ export class UserContextService {
     let preferences = new UserContextPreferences();
 
     if (data.wallet) {
-      preferences = this._storage.getLocalStorage(data?.wallet, true);
+      preferences = this._storage.getLocalStorage(data.wallet, true);
     }
 
     return new UserContext(data.wallet, preferences);
@@ -44,7 +44,7 @@ export class UserContextService {
 
   logout(): void {
     this._token = undefined;
-    this._jwtService.setToken(this._token);
+    this._jwtService.setToken(undefined);
     this._userContext$.next(new UserContext());
   }
 

--- a/src/app/services/utility/user-context.service.ts
+++ b/src/app/services/utility/user-context.service.ts
@@ -32,6 +32,12 @@ export class UserContextService {
     this.userContext$.next(updatedContext);
   }
 
+  logout(): void {
+    this._token = undefined;
+    this._jwtService.setToken(this._token);
+    this.userContext$.next(new UserContext());
+  }
+
   setUserPreferences(wallet: string, preferences: UserContextPreferences): void {
     this._storage.setLocalStorage(wallet, preferences, true);
 

--- a/src/app/views/auth/auth.component.ts
+++ b/src/app/views/auth/auth.component.ts
@@ -17,7 +17,7 @@ export class AuthComponent {
   iconSizes = IconSizes;
 
   constructor(
-    private _context: UserContextService,
+    private _userContextService: UserContextService,
     private _router: Router,
     private _theme: ThemeService,
     private _activatedRoute: ActivatedRoute,
@@ -25,7 +25,7 @@ export class AuthComponent {
   ) { }
 
   async ngOnInit() {
-    const currentContext = this._context.userContext;
+    const currentContext = this._userContextService.userContext;
 
     if (currentContext.wallet) {
       this._router.navigateByUrl('/');
@@ -39,7 +39,7 @@ export class AuthComponent {
     this.authFailure = !verification.success;
 
     if (verification.success) {
-      const { preferences } = this._context.userContext;
+      const { preferences } = this._userContextService.userContext;
       if (preferences?.theme) this._theme.setTheme(preferences.theme);
 
       this._router.navigate([verification.routePath], verification.routeQueryParams);

--- a/src/app/views/auth/auth.component.ts
+++ b/src/app/views/auth/auth.component.ts
@@ -34,7 +34,7 @@ export class AuthComponent {
 
     const accessCode = this._activatedRoute.snapshot.queryParamMap.get('code');
     const state = this._activatedRoute.snapshot.queryParamMap.get('state');
-    const verification = await this._authService.verify(accessCode, state);
+    const verification = await this._authService.verifyLogin(accessCode, state);
 
     this.authFailure = !verification.success;
 
@@ -47,6 +47,6 @@ export class AuthComponent {
   }
 
   login(): void {
-    this._authService.login();
+    this._authService.prepareLogin();
   }
 }

--- a/src/app/views/auth/auth.component.ts
+++ b/src/app/views/auth/auth.component.ts
@@ -25,7 +25,7 @@ export class AuthComponent {
   ) { }
 
   async ngOnInit() {
-    const currentContext = this._context.getUserContext();
+    const currentContext = this._context.userContext;
 
     if (currentContext.wallet) {
       this._router.navigateByUrl('/');
@@ -39,7 +39,7 @@ export class AuthComponent {
     this.authFailure = !verification.success;
 
     if (verification.success) {
-      const { preferences } = this._context.getUserContext();
+      const { preferences } = this._context.userContext;
       if (preferences?.theme) this._theme.setTheme(preferences.theme);
 
       this._router.navigate([verification.routePath], verification.routeQueryParams);

--- a/src/app/views/login/login.component.ts
+++ b/src/app/views/login/login.component.ts
@@ -8,6 +8,6 @@ import { AuthService } from '@sharedServices/utility/auth.service';
 })
 export class LoginComponent {
   constructor(private _authService: AuthService) {
-    this._authService.login();
+    this._authService.prepareLogin();
   }
 }

--- a/src/app/views/mining-governance/mining-governance.component.ts
+++ b/src/app/views/mining-governance/mining-governance.component.ts
@@ -45,7 +45,7 @@ export class MiningGovernanceComponent implements OnInit, OnDestroy {
     private _platformApiService: PlatformApiService,
     private _miningGovernanceService: MiningGovernancesService,
     private _bottomSheet: MatBottomSheet,
-    private _context: UserContextService,
+    private _userContextService: UserContextService,
     private _tokenService: TokensService,
     private _liquidityPoolsService: LiquidityPoolsService,
     private _indexService: IndexService,
@@ -55,7 +55,7 @@ export class MiningGovernanceComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.context = this._context.userContext;
+    this.context = this._userContextService.userContext;
 
     this.subscription.add(
       this._indexService.latestBlock$

--- a/src/app/views/mining-governance/mining-governance.component.ts
+++ b/src/app/views/mining-governance/mining-governance.component.ts
@@ -55,7 +55,7 @@ export class MiningGovernanceComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.context = this._context.getUserContext();
+    this.context = this._context.userContext;
 
     this.subscription.add(
       this._indexService.latestBlock$

--- a/src/app/views/pool/pool.component.ts
+++ b/src/app/views/pool/pool.component.ts
@@ -68,7 +68,7 @@ export class PoolComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.init();
-    this.context$ = this._userContext.getUserContext$();
+    this.context$ = this._userContext.userContext$;
 
     this.routerSubscription.add(
       this._router.events.subscribe((evt) => {
@@ -179,7 +179,7 @@ export class PoolComponent implements OnInit, OnDestroy {
   // }
 
   // getWalletSummary(): void {
-  //   const context = this._userContext.getUserContext();
+  //   const context = this._userContext.userContext;
 
   //   if (context.wallet && this.pool) {
   //     const lpToken = this.pool.tokens.lp;

--- a/src/app/views/pool/pool.component.ts
+++ b/src/app/views/pool/pool.component.ts
@@ -68,7 +68,7 @@ export class PoolComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.init();
-    this.context$ = this._userContext.userContext$;
+    this.context$ = this._userContext.context$;
 
     this.routerSubscription.add(
       this._router.events.subscribe((evt) => {

--- a/src/app/views/pools/pools.component.ts
+++ b/src/app/views/pools/pools.component.ts
@@ -33,7 +33,7 @@ export class PoolsComponent implements OnInit, OnDestroy {
     private _sidebar: SidenavService,
     private _liquidityPoolsService: LiquidityPoolsService,
     private _indexService: IndexService,
-    private _context: UserContextService
+    private _userContextService: UserContextService
   ) {
     this.topPoolsFilter = new LiquidityPoolsFilter({orderBy: LpOrderBy.Liquidity, limit: 10, direction: 'DESC'});
 
@@ -44,7 +44,7 @@ export class PoolsComponent implements OnInit, OnDestroy {
     }
 
     this.subscription.add(
-      this._context.userContext$
+      this._userContextService.context$
         .subscribe(context => this.context = context));
   }
 

--- a/src/app/views/pools/pools.component.ts
+++ b/src/app/views/pools/pools.component.ts
@@ -44,7 +44,7 @@ export class PoolsComponent implements OnInit, OnDestroy {
     }
 
     this.subscription.add(
-      this._context.getUserContext$()
+      this._context.userContext$
         .subscribe(context => this.context = context));
   }
 

--- a/src/app/views/token/token.component.ts
+++ b/src/app/views/token/token.component.ts
@@ -85,7 +85,7 @@ export class TokenComponent implements OnInit {
     this.subscription.add(
       this._indexService.latestBlock$
         .pipe(
-          switchMap(_ => this._userContextService.getUserContext$().pipe(tap(context => this.context = context))),
+          switchMap(_ => this._userContextService.userContext$.pipe(tap(context => this.context = context))),
           switchMap(_ => this.getToken()),
           tap(_ => this.historyFilter?.refresh()),
           switchMap(_ => this.getTokenHistory()),

--- a/src/app/views/token/token.component.ts
+++ b/src/app/views/token/token.component.ts
@@ -85,7 +85,7 @@ export class TokenComponent implements OnInit {
     this.subscription.add(
       this._indexService.latestBlock$
         .pipe(
-          switchMap(_ => this._userContextService.userContext$.pipe(tap(context => this.context = context))),
+          switchMap(_ => this._userContextService.context$.pipe(tap(context => this.context = context))),
           switchMap(_ => this.getToken()),
           tap(_ => this.historyFilter?.refresh()),
           switchMap(_ => this.getTokenHistory()),

--- a/src/app/views/vault-proposal/vault-proposal.component.ts
+++ b/src/app/views/vault-proposal/vault-proposal.component.ts
@@ -56,7 +56,7 @@ export class VaultProposalComponent {
     private _indexService: IndexService,
     private _sidebar: SidenavService,
     private _route: ActivatedRoute,
-    private _context: UserContextService,
+    private _userContextService: UserContextService,
     private _title: Title,
     private _gaService: GoogleAnalyticsService,
     private _platformApiService: PlatformApiService,
@@ -70,7 +70,7 @@ export class VaultProposalComponent {
     this._gaService.pageView(this._route.routeConfig.path, pageName);
 
     this.subscription.add(
-      this._context.userContext$
+      this._userContextService.context$
         .subscribe(context => this.context = context));
 
     this.subscription.add(

--- a/src/app/views/vault-proposal/vault-proposal.component.ts
+++ b/src/app/views/vault-proposal/vault-proposal.component.ts
@@ -70,7 +70,7 @@ export class VaultProposalComponent {
     this._gaService.pageView(this._route.routeConfig.path, pageName);
 
     this.subscription.add(
-      this._context.getUserContext$()
+      this._context.userContext$
         .subscribe(context => this.context = context));
 
     this.subscription.add(

--- a/src/app/views/vault/vault.component.ts
+++ b/src/app/views/vault/vault.component.ts
@@ -65,7 +65,7 @@ export class VaultComponent implements OnInit {
       direction: 'DESC'
     } as IVaultCertificatesFilter);
 
-    this.subscription.add(this._context.getUserContext$().subscribe(context => this.context = context));
+    this.subscription.add(this._context.userContext$.subscribe(context => this.context = context));
 
     this.transactionsRequest = {
       limit: 15,

--- a/src/app/views/vault/vault.component.ts
+++ b/src/app/views/vault/vault.component.ts
@@ -49,7 +49,7 @@ export class VaultComponent implements OnInit {
     private _indexService: IndexService,
     private _env: EnvironmentsService,
     private _sidebar: SidenavService,
-    private _context: UserContextService
+    private _userContextService: UserContextService
   ) {
     // Init with null to get default/loading animations
     this.statCards = VaultStatCardsLookup.getStatCards(null, null);
@@ -65,7 +65,7 @@ export class VaultComponent implements OnInit {
       direction: 'DESC'
     } as IVaultCertificatesFilter);
 
-    this.subscription.add(this._context.userContext$.subscribe(context => this.context = context));
+    this.subscription.add(this._userContextService.context$.subscribe(context => this.context = context));
 
     this.transactionsRequest = {
       limit: 15,

--- a/src/app/views/wallet/wallet.component.ts
+++ b/src/app/views/wallet/wallet.component.ts
@@ -58,7 +58,7 @@ export class WalletComponent implements OnInit {
     private _sidebar: SidenavService,
     private _env: EnvironmentsService
   ) {
-    this.wallet = this._context.getUserContext();
+    this.wallet = this._context.userContext;
     this.showProposals = !!this._env.vaultAddress;
 
     if (!this.wallet || !this.wallet.wallet) {

--- a/src/app/views/wallet/wallet.component.ts
+++ b/src/app/views/wallet/wallet.component.ts
@@ -51,14 +51,14 @@ export class WalletComponent implements OnInit {
   mining: CollapsableTable<MiningPositionsFilter>;
 
   constructor(
-    private _context: UserContextService,
+    private _userContextService: UserContextService,
     private _tokensService: TokensService,
     private _walletsService: WalletsService,
     private _router: Router,
     private _sidebar: SidenavService,
     private _env: EnvironmentsService
   ) {
-    this.wallet = this._context.userContext;
+    this.wallet = this._userContextService.userContext;
     this.showProposals = !!this._env.vaultAddress;
 
     if (!this.wallet || !this.wallet.wallet) {
@@ -139,12 +139,12 @@ export class WalletComponent implements OnInit {
 
   handleDeadlineChange(threshold: number): void {
     this.wallet.preferences.deadlineThreshold = threshold;
-    this._context.setUserPreferences(this.wallet.wallet, this.wallet.preferences);
+    this._userContextService.setUserPreferences(this.wallet.wallet, this.wallet.preferences);
   }
 
   handleToleranceChange(threshold: number): void {
     this.wallet.preferences.toleranceThreshold = threshold;
-    this._context.setUserPreferences(this.wallet.wallet, this.wallet.preferences);
+    this._userContextService.setUserPreferences(this.wallet.wallet, this.wallet.preferences);
   }
 
   togglePreferences(): void {


### PR DESCRIPTION
Work in progress PR for auth flows that include refresh tokens enabling users to securely stay logged in for much longer periods of times. 

- [x] Access tokens never stored in local storage
- [x] Store refresh tokens, refresh on page load for access token
- [x] Use interceptor to auto refresh on 401 response
- [x] Hard logout and user flow UX for expired refresh tokens w/ 403 response
- [x] Auto refresh when possible and access token is near expiration, prior to 401 failures